### PR TITLE
Fix Activity instance leaking because retained by DI

### DIFF
--- a/Sources/sdk/src/main/java/com/batch/android/Batch.java
+++ b/Sources/sdk/src/main/java/com/batch/android/Batch.java
@@ -2305,7 +2305,7 @@ public final class Batch
                 /*
                  * Warm up the local broadcast manager
                  */
-                LocalBroadcastManagerProvider.get(context);
+                LocalBroadcastManagerProvider.get(context.getApplicationContext());
 
                 /*
                  * Check for update migration stuff


### PR DESCRIPTION
The first Activity that goes through `BatchActivityLifecycleHelper` to init Batch would have been retained forever.

<!-- We don’t accept pull requests at the moment. Please reach out to our support team at support@batch.com or via the Live-Chat, or open an issue. -->
